### PR TITLE
Adding documentation to set different base URL

### DIFF
--- a/moinmoincli.conf.sample
+++ b/moinmoincli.conf.sample
@@ -4,6 +4,9 @@
 # The password for the account.
 #password='secret'
 
+# The base URL for the MoinMoin wiki pages.
+#base=https://wiki.FreeBSD.org
+
 # The default target It's used unless a selector or the -t flag is used.
 target='/WikiSandBox'
 


### PR DESCRIPTION
For testing, one may want to use a different base URL for updating pages.

This allows you to set a different URL for testing.